### PR TITLE
Add link to the review page in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,7 @@ zypper dup
 
 The repo URLs are effectively the only part of the `libzypp` configuration that
 is being changed. This keeps the workflow changes to a minimum.
+
+## Tumbleweed review
+
+You can find a scored review of each snapshot under: http://review.tumbleweed.boombatower.com/


### PR DESCRIPTION
I think it is very handy to have the link to the review page in the readme file.

I often tried to show this to other while not being on my computer (no bookmarks) and google is not showing good results until you visit that page often. But the github project is very easy to find.

Can it maybe also be useful for others?