### PR TITLE
Add reviews functionality

### DIFF
--- a/tumbleweed
+++ b/tumbleweed
@@ -3,6 +3,7 @@
 VERSION="development"
 URL_PRE_MIGRATE="http://download.tumbleweed.boombatower.com"
 URL_POST_MIGRATE="http://download.opensuse.org/history"
+URL_REVIEWS="https://review.tumbleweed.boombatower.com/data"
 CONFIG_DIR="/etc/zypp"
 VARS_DIR="$CONFIG_DIR/vars.d"
 VAR_NAME="snapshotVersion"
@@ -291,6 +292,22 @@ tumbleweed_unmigrate()
   sudo rm -r "$REPOS_DIR/.migrated"
 }
 
+tumbleweed_reviews()
+{
+  local reviews_yml_all=$(curl -s "$URL_REVIEWS/score.yaml")
+  local reviews_yml=$(echo "$reviews_yml_all" | tail -n 300)
+  local releases=$(echo "$reviews_yml" | grep -E "^'([0-9]{8})':$" | grep -oE "[0-9]{8}" | sort -r)
+
+  echo "Release  | Rating | Stability"
+  echo "-----------------------------"
+  for r in $releases; do
+    local data=$(echo "$reviews_yml" | grep -A2 "$r")
+    local score=$(echo "$data" | awk 'NR==2' | cut -d':' -f2)
+    local stability=$(echo "$data" | awk 'NR==3' | cut -d':' -f2)
+    echo "$r |   $score  | $stability"
+  done
+}
+
 tumbleweed_usage()
 {
   cat <<_EOF_
@@ -316,6 +333,7 @@ revert                Revert to the previous snapshot or repo state.
 uninit                Revert back to a snapshotless repository setup.
 migrate               Migrate from boombatower hosting to download.opensuse.org.
 unmigrate             Revert migration to official hosting.
+reviews               Show release reviews and ratings
 _EOF_
 }
 
@@ -326,7 +344,7 @@ tumbleweed_handle()
     --force) force=1 ; ;;
     --install) install=1 ; ;;
     -h|--help) command="usage" ; ;;
-    history|init|installed|latest|list|revert|status|target|uninit|update|migrate|unmigrate)
+    history|init|installed|latest|list|revert|status|target|uninit|update|migrate|unmigrate|reviews)
       command="$1" ; ;;
     version)
       command="installed" ; ;;

--- a/tumbleweed-completion.bash
+++ b/tumbleweed-completion.bash
@@ -3,7 +3,7 @@
 _tumbleweed_completion()
 {
   if [ ${#COMP_WORDS[@]} -eq 2 ] ; then
-    COMPREPLY=($(compgen -W "history init installed latest list migrate revert status switch target uninit unmigrate update upgrade version --version --help" -- "${COMP_WORDS[-1]}"))
+    COMPREPLY=($(compgen -W "history init installed latest list migrate revert status switch target uninit unmigrate update upgrade reviews version --version --help" -- "${COMP_WORDS[-1]}"))
   elif [[ ${#COMP_WORDS[@]} -gt 2 && (
       "${COMP_WORDS[1]}" == "init" ||
       "${COMP_WORDS[1]}" == "switch" ||


### PR DESCRIPTION
Sample output:
```
tumbleweed reviews                                                                                                                                                                                                 ✔  13:04:07 
Release  | Rating | Stability
-----------------------------
20210426 |    94  |  pending
20210425 |    91  |  pending
20210423 |    87  |  pending
20210422 |    97  |  pending
20210420 |    96  |  stable
20210418 |    97  |  stable
20210417 |    98  |  stable
20210416 |    95  |  stable
20210415 |    94  |  stable
20210414 |    91  |  stable
20210408 |    82  |  moderate
20210406 |    96  |  stable
20210401 |    96  |  stable
20210330 |    96  |  stable
20210329 |    92  |  stable
20210325 |    87  |  moderate
20210321 |    93  |  stable
20210320 |    93  |  stable
20210319 |    94  |  stable
20210318 |    89  |  moderate
20210317 |    94  |  stable
20210316 |    97  |  stable
20210315 |    96  |  stable
20210312 |    92  |  stable
20210311 |    86  |  moderate
20210307 |    94  |  stable
20210306 |    98  |  stable
20210305 |    96  |  stable
20210302 |    93  |  stable
20210227 |    91  |  stable
20210223 |    83  |  moderate
20210222 |    67  |  unstable
20210220 |    97  |  stable
20210219 |    96  |  stable
20210218 |    94  |  stable
20210217 |    86  |  moderate
20210215 |    83  |  moderate
20210212 |    64  |  unstable
20210210 |    89  |  moderate
20210209 |    94  |  stable
20210208 |    86  |  moderate
20210205 |    94  |  stable
20210203 |    95  |  stable
20210202 |    93  |  stable
20210131 |    97  |  stable
20210130 |    97  |  stable
20210128 |    96  |  stable
20210127 |    95  |  stable
20210126 |    91  |  stable
20210121 |    94  |  stable
20210120 |    98  |  stable
20210119 |    97  |  stable
20210118 |    96  |  stable
20210115 |    94  |  stable
20210114 |    98  |  stable
20210113 |    97  |  stable
20210111 |    96  |  stable
20210110 |    95  |  stable
20210108 |    89  |  moderate
20210107 |    97  |  stable
20210106 |    97  |  stable
20210105 |    94  |  stable
20210104 |    88  |  moderate
20210103 |    96  |  stable
20210102 |    99  |  stable
20210101 |    98  |  stable
20201231 |    97  |  stable
20201229 |    96  |  stable
20201228 |    92  |  stable
20201226 |    95  |  stable
20201224 |    91  |  stable
20201223 |    96  |  stable
20201221 |    92  |  stable
20201218 |    84  |  moderate
20201216 |    98  |  stable
20201215 |    98  |  stable
20201214 |    97  |  stable
20201213 |    94  |  stable
20201212 |    85  |  moderate
20201211 |    98  |  stable
20201209 |    96  |  stable
20201207 |    94  |  stable
20201205 |    91  |  stable
20201203 |    88  |  moderate
20201202 |    97  |  stable
20201201 |    95  |  stable
20201130 |    97  |  stable
20201129 |    94  |  stable
20201127 |    88  |  moderate
20201125 |    84  |  moderate
20201124 |    76  |  moderate
20201123 |    52  |  unstable
20201121 |    79  |  moderate
20201119 |    64  |  unstable
20201117 |    76  |  moderate
20201114 |    53  |  unstable
20201108 |    87  |  moderate
20201107 |    92  |  stable
20201106 |    91  |  stable
20201105 |    91  |  stable

```