### PR TITLE
tumbleweed: allow handling of redirects

### DIFF
--- a/tumbleweed
+++ b/tumbleweed
@@ -113,7 +113,7 @@ tumbleweed_status()
 
 tumbleweed_latest()
 {
-  curl --fail --silent "$URL/latest"
+  curl --fail --silent -L "$URL/latest"
 }
 
 tumbleweed_target()
@@ -128,7 +128,7 @@ tumbleweed_installed()
 
 tumbleweed_list()
 {
-  curl --fail --silent "$URL/list"
+  curl --fail --silent -L "$URL/list"
 }
 
 tumbleweed_update()
@@ -224,7 +224,7 @@ tumbleweed_migrate_check()
 
   # Issue notice of official hosting and migration if target is available.
   if [ $MIGRATED -eq 0 ] && \
-    curl --fail --silent "$URL_POST_MIGRATE/list" | grep -Fx "$(tumbleweed_target)" > /dev/null ; then
+    curl --fail --silent -L "$URL_POST_MIGRATE/list" | grep -Fx "$(tumbleweed_target)" > /dev/null ; then
     echo "NOTICE: Official snapshot hosting is now available. The unofficial hosting is" >&2
     echo "        deprecated and will be discontinued at a future date. Consider" >&2
     echo "        migrating to the official hosting via \`tumbleweed migrate\`." >&2
@@ -247,7 +247,7 @@ tumbleweed_migrate()
   echo
 
   local count_pre=$(curl --fail --silent "$URL_PRE_MIGRATE/list" | wc -l)
-  local count_post=$(curl --fail --silent "$URL_POST_MIGRATE/list" | wc -l)
+  local count_post=$(curl --fail --silent -L "$URL_POST_MIGRATE/list" | wc -l)
   echo "- unofficial, $URL_PRE_MIGRATE: $count_pre snapshots"
   echo "- official, $URL_POST_MIGRATE: $count_post snapshots"
   echo


### PR DESCRIPTION
Just recently download.opensuse.org started redirecting me to a CDN, which curl doesn't follow by default. As a result it was impossible to obtain the latest snapshot information and `tumbleweed upgrade` failed.